### PR TITLE
fix: devcontainerファイアウォール設定にVSCode Unpkgドメインを追加

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -55,6 +55,7 @@ for domain in \
     "registry.npmjs.org" \
     "api.anthropic.com" \
     "sentry.io" \
+    "www.vscode-unpkg.net" \
     "statsig.anthropic.com" \
     "statsig.com"; do
     echo "Resolving $domain..."


### PR DESCRIPTION
www.vscode-unpkg.net を許可ドメインリストに追加してVSCode拡張機能の正常な動作を確保

🤖 Generated with [Claude Code](https://claude.ai/code)