### PR TITLE
create-commit commandsのdescriptionを修正

### DIFF
--- a/.claude/commands/create-commit.md
+++ b/.claude/commands/create-commit.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git branch), Bash(git diff:*), Bash(git add:*), Read, Edit, Glob, Grep, LS
-description: 現在の変更を元に新しいブランチを作成
+description: 現在の変更を元に新しいコミットを作成
 ---
 
 # やること


### PR DESCRIPTION
create-commit commandsのdescriptionが"ブランチを作成"となっていたので"コミットを作成"に修正しました