### PR TITLE
fix: フックスクリプトのパスを$CLAUDE_PROJECT_DIR環境変数使用に修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/block-file-edits.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-file-edits.sh"
           }
         ]
       }
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/notify-require.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify-require.sh"
           }
         ]
       }
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/notify-finish.sh"
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/notify-finish.sh"
           }
         ]
       }


### PR DESCRIPTION
https://docs.anthropic.com/en/docs/claude-code/hooks#project-specific-hook-scripts を参照し、
フックスクリプトのパスを相対パスから$CLAUDE_PROJECT_DIR環境変数を使用した
絶対パスに変更。これによりプロジェクトディレクトリの場所に依存しない
堅牢な設定となる。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>