### PR TITLE
fix: CNAMEを再帰的にIP取得する

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -2,6 +2,9 @@
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 
+# 1. Extract Docker DNS info BEFORE any flushing
+DOCKER_DNS_RULES=$(iptables-save -t nat | grep "127\.0\.0\.11" || true)
+
 # Flush existing rules and delete existing ipsets
 iptables -F
 iptables -X
@@ -10,6 +13,16 @@ iptables -t nat -X
 iptables -t mangle -F
 iptables -t mangle -X
 ipset destroy allowed-domains 2>/dev/null || true
+
+# 2. Selectively restore ONLY internal Docker DNS resolution
+if [ -n "$DOCKER_DNS_RULES" ]; then
+    echo "Restoring Docker DNS rules..."
+    iptables -t nat -N DOCKER_OUTPUT 2>/dev/null || true
+    iptables -t nat -N DOCKER_POSTROUTING 2>/dev/null || true
+    echo "$DOCKER_DNS_RULES" | xargs -L 1 iptables -t nat
+else
+    echo "No Docker DNS rules to restore"
+fi
 
 # First allow DNS and localhost before any restrictions
 # Allow outbound DNS
@@ -50,6 +63,62 @@ while read -r cidr; do
     ipset add allowed-domains "$cidr"
 done < <(echo "$gh_ranges" | jq -r '(.web + .api + .git)[]' | aggregate -q)
 
+# Function to resolve domain through CNAME chain with specified depth
+resolve_domain_to_ips() {
+    local domain="$1"
+    local max_depth="${2:-3}"
+    local current_depth=0
+    local current_domain="$domain"
+    local final_ips=""
+    
+    echo "Resolving $domain (max depth: $max_depth)..." >&2
+    
+    while [ $current_depth -lt $max_depth ]; do
+        echo "  Depth $((current_depth + 1)): Checking $current_domain" >&2
+        
+        # Get CNAME records specifically first
+        local cname=$(dig +short CNAME "$current_domain" | head -1)
+        
+        if [ -n "$cname" ]; then
+            # Remove trailing dot from CNAME if present
+            cname=$(echo "$cname" | sed 's/\.$//')
+            echo "  Following CNAME: $current_domain -> $cname" >&2
+            current_domain="$cname"
+            current_depth=$((current_depth + 1))
+            continue
+        fi
+        
+        # If no CNAME, try to get A records (IP addresses)
+        local ips=$(dig +short A "$current_domain" | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$')
+        
+        if [ -n "$ips" ]; then
+            echo "  Found IP addresses for $current_domain" >&2
+            final_ips="$ips"
+            break
+        fi
+        
+        echo "  No CNAME or A record found for $current_domain" >&2
+        break
+    done
+    
+    if [ $current_depth -eq $max_depth ]; then
+        echo "  Reached maximum depth ($max_depth) for $domain, trying final resolution" >&2
+        # Try one final resolution at max depth
+        local ips=$(dig +short A "$current_domain" | grep -E '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$')
+        if [ -n "$ips" ]; then
+            echo "  Found IP addresses for $current_domain at max depth" >&2
+            final_ips="$ips"
+        fi
+    fi
+    
+    if [ -z "$final_ips" ]; then
+        echo "  ERROR: Failed to resolve $domain to IP addresses" >&2
+        return 1
+    fi
+    
+    echo "$final_ips"
+}
+
 # Resolve and add other allowed domains
 for domain in \
     "registry.npmjs.org" \
@@ -58,9 +127,9 @@ for domain in \
     "www.vscode-unpkg.net" \
     "statsig.anthropic.com" \
     "statsig.com"; do
-    echo "Resolving $domain..."
-    ips=$(dig +short A "$domain")
-    if [ -z "$ips" ]; then
+    
+    ips=$(resolve_domain_to_ips "$domain" 10)
+    if [ $? -ne 0 ] || [ -z "$ips" ]; then
         echo "ERROR: Failed to resolve $domain"
         exit 1
     fi


### PR DESCRIPTION
www.vscode-unpkg.net は CNAME レコードを返すため、init-firewallでエラーが出ていた。 CNAME レコードを再帰的に見るようにする。

また、upstream を参考にスクリプトを調整。
https://github.com/anthropics/claude-code/blob/5faa082d6e4e5300485daafb94615fe133175055/.devcontainer/init-firewall.sh