### PR TITLE
fix: Squidプロキシ設定にconsole.anthropic.comドメインを追加

### DIFF
--- a/.devcontainer/squid.conf
+++ b/.devcontainer/squid.conf
@@ -65,6 +65,7 @@ acl vscode_domains dstdomain default.exp-tas.com
 # Claude Code domains
 # ref: https://github.com/anthropics/claude-code/blob/5faa082d6e4e5300485daafb94615fe133175055/.devcontainer/init-firewall.sh#L68-L72
 acl claude_code_domains dstdomain registry.npmjs.org
+acl claude_code_domains dstdomain console.anthropic.com
 acl claude_code_domains dstdomain api.anthropic.com
 acl claude_code_domains dstdomain sentry.io
 acl claude_code_domains dstdomain statsig.anthropic.com


### PR DESCRIPTION
Claude Codeの動作に必要なconsole.anthropic.comドメインがSquidプロキシの許可リストに含まれていなかったため追加。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>