### PR TITLE
feat: SquidプロキシにJetBrains IDEサポートを追加

### DIFF
--- a/.devcontainer/squid.conf
+++ b/.devcontainer/squid.conf
@@ -62,6 +62,18 @@ acl vscode_domains dstdomain vscode.dev
 acl vscode_domains dstdomain .vscode-unpkg.net
 acl vscode_domains dstdomain default.exp-tas.com
 
+# JetBrains services
+# ref: https://youtrack.jetbrains.com/articles/SUPPORT-A-288/Whats-the-IP-whitelist-of-IntelliJ-IDE-in-case-of-firewall-policy-or-restricted-network
+acl jetbrains_domains dstdomain www.jetbrains.com
+acl jetbrains_domains dstdomain download.jetbrains.com
+acl jetbrains_domains dstdomain download-cf.jetbrains.com
+acl jetbrains_domains dstdomain download-cdn.jetbrains.com
+acl jetbrains_domains dstdomain plugins.jetbrains.com
+acl jetbrains_domains dstdomain account.jetbrains.com
+acl jetbrains_domains dstdomain cloudconfig.jetbrains.com
+acl jetbrains_domains dstdomain api.app.prod.grazie.aws.intellij.net
+acl jetbrains_domains dstdomain api.jetbrains.ai
+
 # Claude Code domains
 # ref: https://github.com/anthropics/claude-code/blob/5faa082d6e4e5300485daafb94615fe133175055/.devcontainer/init-firewall.sh#L68-L72
 acl claude_code_domains dstdomain registry.npmjs.org
@@ -96,10 +108,12 @@ http_access allow container_clients vscode_domains
 http_access allow container_clients github_domains
 http_access allow container_clients claude_code_domains
 http_access allow container_clients cdn_domains
+http_access allow container_clients jetbrains_domains
 http_access allow CONNECT container_clients SSL_ports vscode_domains
 http_access allow CONNECT container_clients SSL_ports github_domains
 http_access allow CONNECT container_clients SSL_ports claude_code_domains
 http_access allow CONNECT container_clients SSL_ports cdn_domains
+http_access allow CONNECT container_clients SSL_ports jetbrains_domains
 
 # Allow DNS queries (only from container clients)
 http_access allow container_clients dns_servers


### PR DESCRIPTION
IntelliJ IDEA等のJetBrains IDE利用時に必要なドメインを許可リストに追加。
プラグインダウンロード、アカウント認証、AIアシスタント機能等に対応。

🤖 Generated with [Claude Code](https://claude.ai/code)